### PR TITLE
Add native "date" field type for ticket additional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ function custom_tickets_additional_fields( $ticket_fields ) {
 			'description' => esc_html__( 'Insert the event date.' ),
 		];
 
+		$ticket_fields['event_type'] = [
+			'type'        => 'select',
+			'label'       => esc_html__( 'Event type' ),
+			'description' => esc_html__( 'Choose the event type.' ),
+			// value => label
+			'options'     => [
+				'workshop' => esc_html__( 'Workshop' ),
+				'course'   => esc_html__( 'Course'),
+				'webinar'  => esc_html__( 'Webinar'),
+			],
+			// optional:
+			'placeholder' => esc_html__( 'Please choose…' ),
+		];
+
 		return $ticket_fields;
 }
 
@@ -124,3 +138,4 @@ function my_custom_additional_field_shortcode_printing( $html, $ticket_id, $fiel
 * `number` - Number.
 * `checkbox` - Checkbox.
 * `date` - HTML5 Date selector.
+* `select` - Dropdown select. Requires an `options` array with `value => label` pairs.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ function custom_tickets_additional_fields( $ticket_fields ) {
 			'description' => esc_html__( 'Insert the youtube embed of the video they have access to when they purchase the ticket.' ),
 		];
 
+		$ticket_fields['event_date'] = [
+			'type'        => 'date',
+			'label'       => esc_html__( 'Event date' ),
+			'description' => esc_html__( 'Insert the event date.' ),
+		];
+
 		return $ticket_fields;
 }
 
@@ -117,3 +123,4 @@ function my_custom_additional_field_shortcode_printing( $html, $ticket_id, $fiel
 * `email` - Email (when being printed for the shortcode will add the HTML for the email link).
 * `number` - Number.
 * `checkbox` - Checkbox.
+* `date` - HTML5 Date selector.

--- a/src/Tribe/Shortcodes/Tribe_Tickets_Additional_Field.php
+++ b/src/Tribe/Shortcodes/Tribe_Tickets_Additional_Field.php
@@ -86,6 +86,9 @@ class Tribe_Tickets_Additional_Field extends \Tribe\Shortcode\Shortcode_Abstract
 			case 'date':
 				$html = $this->get_date_render( $ticket_id, $field );
 				break;
+			case 'select':
+				$html = $this->get_select_render( $ticket_id, $field );
+				break;
 			default:
 				$html = $meta->get_field_value( $ticket_id, $meta->get_field_id( $field ), true );
 		}
@@ -161,4 +164,48 @@ class Tribe_Tickets_Additional_Field extends \Tribe\Shortcode\Shortcode_Abstract
 		}
 	}
 
+	/**
+	 * Gets the additional render, when it's Select type.
+	 *
+	 * @param int|WP_Post $ticket The ticket.
+	 * @param string      $field  Field key.
+	 *
+	 * @return string
+	 */
+	public function get_select_render( $ticket_id, $field ) {
+		$meta  = tribe( 'tickets.additional-fields.fields' );
+
+		$field_id = $meta->get_field_id( $field );
+		$value    = $meta->get_field_value( $ticket_id, $field_id, true );
+		$value    = is_string( $value ) ? trim( $value ) : '';
+
+		if ( $value === '' ) {
+			return '';
+		}
+
+		// Feld-Definitionen über den bekannten Filter holen.
+		$fields = apply_filters( 'tribe_ext_tickets_additional_fields', [] );
+
+		if ( isset( $fields[ $field ]['options'][ $value ] ) ) {
+			$label = $fields[ $field ]['options'][ $value ]; // Label aus options
+		} else {
+			$label = $value; // Fallback: Key direkt
+		}
+
+		/**
+		 * Filter the output of select field additional field.
+		 */
+		$label = apply_filters(
+			'tribe_ext_tickets_additional_fields_select_display',
+			$label,
+			$ticket_id,
+			$field,
+			$value
+		);
+
+		return esc_html( (string) $label );
 	}
+
+
+
+}

--- a/src/Tribe/Shortcodes/Tribe_Tickets_Additional_Field.php
+++ b/src/Tribe/Shortcodes/Tribe_Tickets_Additional_Field.php
@@ -83,6 +83,9 @@ class Tribe_Tickets_Additional_Field extends \Tribe\Shortcode\Shortcode_Abstract
 			case 'email':
 				$html = $this->get_email_render( $ticket_id, $field );
 				break;
+			case 'date':
+				$html = $this->get_date_render( $ticket_id, $field );
+				break;
 			default:
 				$html = $meta->get_field_value( $ticket_id, $meta->get_field_id( $field ), true );
 		}
@@ -132,4 +135,30 @@ class Tribe_Tickets_Additional_Field extends \Tribe\Shortcode\Shortcode_Abstract
 		return '<a href="mailto:' . $email . '">' . $email . '</a>';
 	}
 
-}
+	/**
+	 * Gets the additional render, when it's Date type
+	 *
+	 * @param WP_Post|int $ticket   the post/event we're viewing.
+	 * @param string      $field_id the additional field we want to retrieve.
+	 *
+	 * @return string The resulting HTML.
+	 */
+	public function get_date_render( $ticket_id, $field ) {
+		$meta  = tribe( 'tickets.additional-fields.fields' );
+		$value = $meta->get_field_value( $ticket_id, $meta->get_field_id( $field ), true );
+		$value = is_string( $value ) ? trim( $value ) : '';
+
+		if ( $value !== '' && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $value ) ) {
+			try {
+				$dt = new \DateTimeImmutable( $value, wp_timezone() );
+				$format = apply_filters( 'tribe_ext_tickets_additional_fields_date_display_format', 'd.m.Y' );
+				return esc_html( $dt->format( $format ) );
+			} catch ( \Exception $e ) {
+				return esc_html( $value );
+			}
+		} else {
+			return esc_html( $value );
+		}
+	}
+
+	}

--- a/src/admin-views/editor/input-date.php
+++ b/src/admin-views/editor/input-date.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Date input for Additional Ticket Field type "date".
+ *
+ * @var WP_Post $post
+ * @var array   $field_data  The field data.
+ * @var string  $field_id    The field ID.
+ * @var string  $field_value The field value.
+ */
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+?>
+<div class="tribe-ext-tickets-af-field tribe-ext-tickets-af-field--date">
+	<?php if ( ! empty( $field_data['label'] ) ) : ?>
+		<label for="<?php echo esc_attr( $field_id ); ?> class="ticket_form_label ticket_form_left"">
+		<?php echo esc_html( $field_data['label'] ); ?>
+		</label>
+	<?php endif; ?>
+
+	<input
+		id="<?php echo esc_attr( $field_id ); ?>"
+		class="regular-text ticket_field ticket_form_right"
+		type="date"
+		name="<?php echo esc_attr( $field_id ); ?>"
+		value="<?php echo esc_attr( $field_value ); ?>"
+		placeholder="YYYY-MM-DD"
+	/>
+
+	<?php if ( ! empty( $field_data['description'] ) ) : ?>
+		<p class="description"><?php echo esc_html( $field_data['description'] ); ?></p>
+	<?php endif; ?>
+</div>

--- a/src/admin-views/editor/input-select.php
+++ b/src/admin-views/editor/input-select.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Select input for Additional Ticket Field type "select".
+ *
+ * @var WP_Post $post
+ * @var array  $field_data  The field data.
+ * @var string $field_id    The field ID.
+ * @var string $field_value The field value.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Optionen erwarten wir als value => label.
+$options = [];
+if ( ! empty( $field_data['options'] ) && is_array( $field_data['options'] ) ) {
+	$options = $field_data['options'];
+}
+?>
+<div class="tribe-ext-tickets-af-field tribe-ext-tickets-af-field--select">
+	<?php if ( ! empty( $field_data['label'] ) ) : ?>
+		<label
+			for="<?php echo esc_attr( $field_id ); ?>"
+			class="ticket_form_label ticket_form_left"
+		>
+			<?php echo esc_html( $field_data['label'] ); ?>
+		</label>
+	<?php endif; ?>
+
+	<select
+		id="<?php echo esc_attr( $field_id ); ?>"
+		name="<?php echo esc_attr( $field_id ); ?>"
+		class="ticket_field ticket_form_right"
+	>
+		<?php
+		// Optional: leere Option vorne.
+		if ( ! empty( $field_data['placeholder'] ) ) :
+			?>
+			<option value="">
+				<?php echo esc_html( $field_data['placeholder'] ); ?>
+			</option>
+			<?php
+		endif;
+
+		foreach ( $options as $value => $label ) :
+			$value = (string) $value;
+			?>
+			<option
+				value="<?php echo esc_attr( $value ); ?>"
+				<?php selected( $field_value, $value ); ?>
+			>
+				<?php echo esc_html( $label ); ?>
+			</option>
+		<?php endforeach; ?>
+	</select>
+
+	<?php if ( ! empty( $field_data['description'] ) ) : ?>
+		<p class="description">
+			<?php echo esc_html( $field_data['description'] ); ?>
+		</p>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
### Summary
This PR extends the Tickets Additional Fields extension with two native field types: **`date`** and **`select`**.

### Motivation
Events often require structured ticket metadata, e.g.:

- a specific module day or course date
- a controlled choice (language, level, location, etc.)

Until now these values had to be stored as free text.  
This PR introduces proper field types to improve data integrity and UI consistency.

### What this PR does
- Adds new field type **`date`**
  - Renders an HTML5 `<input type="date">` in the ticket editor (Classic + Block)
  - Stores values in ISO format (`YYYY-MM-DD`)
- Adds new field type **`select`**
  - Renders a `<select>` element with configurable options
  - Stores the raw option value; displays the option label in frontend/shortcodes
- Enhances shortcode output to format date values (filterable)

### Technical notes
- No breaking changes
- **Date field**
  - Falls back to raw string if a non-ISO date is stored
  - Output formatting can be customized:
    ```php
    add_filter(
        'tribe_ext_tickets_additional_fields_date_display_format',
        fn() => 'j. F Y'
    );
    ```
- **Select field**
  - Saves option values consistently
  - Frontend output automatically resolves to the configured option label
  - All output is filterable if further customization is needed
  
  @andrasguseo 
